### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ module "dcos-master-instances" {
 | name_prefix | Cluster Name | string | - | yes |
 | network_security_group_id | Security Group Id | string | `` | no |
 | num_masters | Specify the amount of masters. For redundancy you should have at least 3 | string | - | yes |
-| private_backend_address_pool | Private backend address pool | list | `<list>` | no |
-| public_backend_address_pool | Public backend address pool | list | `<list>` | no |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | ssh_private_key_filename | Path to the SSH private key | string | `/dev/null` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | - | yes |
@@ -54,6 +52,8 @@ module "dcos-master-instances" {
 | Name | Description |
 |------|-------------|
 | admin_username | SSH User |
+| instance_nic_ids | List of instance nic ids created by this module |
+| ip_configuration_names | List of instance nic ids created by this module |
 | prereq_id | Prereq id used for dependency |
 | private_ips | List of private ip addresses created by this module |
 | public_ips | List of public ip addresses created by this module |

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,5 @@ module "dcos-master-instances" {
   ssh_public_key               = "${var.ssh_public_key}"
   tags                         = "${var.tags}"
   hostname_format              = "${var.hostname_format}"
-  private_backend_address_pool = ["${var.private_backend_address_pool}"]
-  public_backend_address_pool  = ["${var.public_backend_address_pool}"]
   subnet_id                    = "${var.subnet_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "public_ips" {
   value       = ["${module.dcos-master-instances.public_ips}"]
 }
 
+output "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  value       = ["${module.dcos-master-instances.instance_nic_ids}"]
+}
+
+output "ip_configuration_names" {
+  description = "List of instance nic ids created by this module"
+  value       = ["${module.dcos-master-instances.ip_configuration_names}"]
+}
+
 output "prereq_id" {
   description = "Prereq id used for dependency"
   value       = "${module.dcos-master-instances.prereq_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -107,16 +107,3 @@ variable "network_security_group_id" {
   description = "Security Group Id"
   default     = ""
 }
-
-variable "public_backend_address_pool" {
-  description = "Public backend address pool"
-  type        = "list"
-  default     = []
-}
-
-# Private backend address pool
-variable "private_backend_address_pool" {
-  description = "Private backend address pool"
-  type        = "list"
-  default     = []
-}


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`